### PR TITLE
Fix update button translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             <button id="gps-btn" aria-label="Use GPS" onclick="useCurrentLocation()" class="p-2 bg-sky-600 text-white rounded-full hover:bg-sky-700 focus:outline-none">📍</button>
             <input type="text" id="location" placeholder="Enter location" aria-label="Enter location" class="p-2 text-black rounded border border-gray-300 focus:outline-none focus:border-cyan-500 focus:shadow" />
             <div id="day-cards" class="flex overflow-x-auto gap-2 snap-x"></div>
-            <button onclick="fetchWeather()" aria-label="Update weather forecast" class="p-2 px-4 bg-sky-600 text-white rounded-xl hover:bg-sky-700 focus:outline-none focus:border-cyan-500 focus:shadow">Update</button>
+            <button id="update-btn" onclick="fetchWeather()" aria-label="Update weather forecast" class="p-2 px-4 bg-sky-600 text-white rounded-xl hover:bg-sky-700 focus:outline-none focus:border-cyan-500 focus:shadow">Update</button>
         </section>
         <section class="weather-info fade-in grid grid-cols-1 sm:grid-cols-2 gap-4 w-full mx-auto">
             <div class="weather-item flex flex-col justify-between bg-white/10 p-5 rounded-lg shadow transition hover:-translate-y-1 hover:bg-white/20">

--- a/script.js
+++ b/script.js
@@ -97,7 +97,8 @@
             }
 
             document.getElementById('location').placeholder = lang === 'en' ? translations.en.locationPlaceholder : "Inserisci la località";
-            document.querySelector('.location-input button').textContent = lang === 'en' ? translations.en.updateButton : "Aggiorna";
+            document.getElementById('update-btn').textContent =
+                lang === 'en' ? translations.en.updateButton : 'Aggiorna';
             updateAdvancedButtonText();
         }
 


### PR DESCRIPTION
## Summary
- assign a dedicated `id` to the forecast button
- update `switchLanguage` to modify this element
- keep the GPS button icon-only

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68533afbbc08833081c8176b81127a95