### PR TITLE
Improve responsive layout for day and hour selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,12 @@
     </header>
     <div id="weather-banner" class="fade-in w-full py-4 text-center text-lg">Loading weather conditions...</div>
     <main class="flex flex-col items-center p-5 max-w-2xl w-11/12 gap-5">
-        <section class="location-input flex flex-col sm:flex-row justify-center gap-2 mb-5">
+        <section class="location-input flex flex-wrap items-center gap-2 mb-5">
             <button id="gps-btn" aria-label="Use GPS" onclick="useCurrentLocation()" class="p-2 bg-sky-600 text-white rounded-full hover:bg-sky-700 focus:outline-none">📍</button>
             <input type="text" id="location" placeholder="Enter location" aria-label="Enter location" class="p-2 text-black rounded border border-gray-300 focus:outline-none focus:border-cyan-500 focus:shadow" />
-            <div id="day-cards" class="flex overflow-x-auto gap-2 snap-x"></div>
+            <div id="day-cards" class="flex flex-wrap justify-center gap-2"></div>
+            <div id="hourly-forecast" class="flex overflow-x-auto gap-3 snap-x"></div>
+            <div id="hour-details" class="text-center"></div>
             <button id="update-btn" onclick="fetchWeather()" aria-label="Update weather forecast" class="p-2 px-4 bg-sky-600 text-white rounded-xl hover:bg-sky-700 focus:outline-none focus:border-cyan-500 focus:shadow">Update</button>
         </section>
         <section class="weather-info fade-in grid grid-cols-1 sm:grid-cols-2 gap-4 w-full mx-auto">
@@ -78,8 +80,6 @@
                 <div id="alerts" data-original-text="No alerts">No alerts</div>
             </div>
         </section>
-        <div id="hourly-forecast" class="flex overflow-x-auto gap-3 snap-x mt-4"></div>
-        <div id="hour-details" class="mt-3 text-center"></div>
         <section class="advanced-weather-info fade-in grid grid-cols-1 sm:grid-cols-2 gap-4 w-full mx-auto" style="display: none;">
             <h2 data-translate="advancedDataTitle" data-original-text="Advanced Weather Data" class="text-2xl font-semibold col-span-full">Advanced Weather Data</h2>
             <div class="weather-item flex flex-col justify-between bg-white/10 p-5 rounded-lg shadow transition hover:-translate-y-1 hover:bg-white/20">


### PR DESCRIPTION
## Summary
- keep location input elements in a single wrapped flex row
- allow day cards to wrap so selections stay visible on small screens
- group hourly forecast and details directly under the day selector

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68533ccff2148330ac5be1106fd3db4c