### PR TITLE
fix: Correct time zone handling and center hourly forecast

### DIFF
--- a/script.js
+++ b/script.js
@@ -420,7 +420,11 @@ const weatherApp = {
 
         this.updateBanner(this.getWeatherCondition(current_weather.weathercode));
         this.displayHourlyForecast(hourly);
-        this.updateMainDisplay(new Date().getHours());
+
+        // Get the current hour from the location's timezone, not the user's system
+        const locationTime = new Date(current_weather.time);
+        const locationHour = locationTime.getHours();
+        this.updateMainDisplay(locationHour);
 
         const savedLang = localStorage.getItem('weatherLang') || 'en';
         this.switchLanguage(savedLang);
@@ -457,6 +461,8 @@ const weatherApp = {
         const selectedCard = this.dom.hourlyContainer.querySelector(`[data-hour-index='${hourIndex}']`);
         if(selectedCard) {
             selectedCard.classList.add('active');
+            // Scroll the container to center the active card
+            selectedCard.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
         }
     },
 


### PR DESCRIPTION
This commit fixes two critical bugs related to time handling and your experience:
1. The application was incorrectly using your system time instead of the local time of the selected location. This caused the wrong time and an incorrect day/night theme to be displayed for cities in different time zones.
2. The hourly forecast did not automatically display the current hour, requiring you to scroll manually.

Changes:
- **script.js:**
    - In `updateUI`, the code now parses the `current_weather.time` string from the API to determine the correct local hour of the selected city. This value is then used to update the main display.
    - In `updateMainDisplay`, the `scrollIntoView()` method is now called on the active hour card. This automatically centers the hourly forecast on the current local time, improving usability.